### PR TITLE
changes the directory creation from mkdir() to mkdirs() for support o…

### DIFF
--- a/src/main/java/hr/jkrizanic/maven/plugin/wsdl2html/Wsdl2HtmlMojo.java
+++ b/src/main/java/hr/jkrizanic/maven/plugin/wsdl2html/Wsdl2HtmlMojo.java
@@ -130,7 +130,7 @@ public class Wsdl2HtmlMojo extends AbstractMojo {
         File fileOutputDirectory = new File(this.outputDirectory);
         //If output directory not exist, create it.
         if (!fileOutputDirectory.exists()) {
-            fileOutputDirectory.mkdir();
+            fileOutputDirectory.mkdirs();
         }
 
         StreamSource xmlSource = new StreamSource(this.wsdlDirectory + "/" + wsdlName);


### PR DESCRIPTION
mkdirs enabled the creation of nested directories.

javadocs for mkdirs():

Creates the directory named by this abstract pathname, including any necessary but nonexistent parent directories. Note that if this operation fails it may have succeeded in creating some of the necessary parent directories.

javadocs for mkdir():

Creates the directory named by this abstract pathname.
